### PR TITLE
Display 'edge' value in log

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,6 +7,10 @@ local edge = 30000
 local radius = 2
 --------------
 
+if minetest.settings:get_bool("log_mods") then
+	minetest.log("action", "World edge: " .. edge)
+end
+
 local count = 0
 local waiting_list = {}
 --[[ Explanation of waiting_list table


### PR DESCRIPTION
Simply displays the *edge* setting value in the Minetest log output.